### PR TITLE
Fix extension of files referenced by header

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ find_package(catkin REQUIRED COMPONENTS
   cmake_modules
   geometry_msgs
   nav_msgs
-  pybind11
   pybind11_catkin
   roscpp
   rospy

--- a/include/pyrosmsg/pyrosmsg.h
+++ b/include/pyrosmsg/pyrosmsg.h
@@ -1,7 +1,7 @@
 #ifndef PYROSMSG_H_B5DJTH81
 #define PYROSMSG_H_B5DJTH81
 
-#include <pyrosmsg/converters.h>
-#include <pyrosmsg/serialization.h>
+#include <pyrosmsg/converters.hpp>
+#include <pyrosmsg/serialization.hpp>
 
 #endif /* end of include guard: PYROSMSG_H_B5DJTH81 */


### PR DESCRIPTION
I... don't really know how this was working for anyone?

Or maybe it's a weird behaviour of my system and .h and .hpp should be detected anyways?

Oh well, this fixed it for me. It corrects the error (for google searches):

```bash
Errors     << image_transport_py:make /home/sam/workspaces/roscpp_py_ws/logs/image_transport_py/build.make.061.log
In file included from /home/sam/workspaces/roscpp_py_ws/src/image_transport_py/src/image_transport_py.cpp:7:0:
/home/sam/workspaces/roscpp_py_ws/src/pyrosmsg/include/pyrosmsg/pyrosmsg.h:4:10: fatal error: pyrosmsg/converters.h: No such file or directory
 #include "pyrosmsg/converters.h"
```

It took me embarrassingly long to figure it out.